### PR TITLE
Fix generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash--tmp-72658d99-3382-4ea5-a2e7-8ef579a32d80-artifacts-db-reset.js

### DIFF
--- a/artifacts/db-reset.js
+++ b/artifacts/db-reset.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 #!/usr/bin/env nodejs
 
 "use strict";

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "consolidate": "^0.14.1",
         "csurf": "^1.8.3",
         "dont-sniff-mimetype": "^1.0.0",
+        "dotenv": "^16.4.7",
         "express": "^4.13.4",
         "express-session": "^1.13.0",
         "forever": "^2.0.0",
@@ -2333,6 +2334,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer3": {
@@ -17223,6 +17236,11 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "consolidate": "^0.14.1",
     "csurf": "^1.8.3",
     "dont-sniff-mimetype": "^1.0.0",
+    "dotenv": "^16.4.7",
     "express": "^4.13.4",
     "express-session": "^1.13.0",
     "forever": "^2.0.0",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 "use strict";
 
 const express = require("express");


### PR DESCRIPTION
This PR fixes generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash--tmp-72658d99-3382-4ea5-a2e7-8ef579a32d80-artifacts-db-reset.js.