### PR TITLE
Fix generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash--tmp-b3338df8-e368-45b5-9600-cf63dc17dc03-artifacts-db-reset.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "consolidate": "^0.14.1",
         "csurf": "^1.8.3",
         "dont-sniff-mimetype": "^1.0.0",
+        "dotenv": "^16.4.7",
         "express": "^4.13.4",
         "express-session": "^1.13.0",
         "forever": "^2.0.0",
@@ -2333,6 +2334,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer3": {
@@ -17223,6 +17235,11 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "consolidate": "^0.14.1",
     "csurf": "^1.8.3",
     "dont-sniff-mimetype": "^1.0.0",
+    "dotenv": "^16.4.7",
     "express": "^4.13.4",
     "express-session": "^1.13.0",
     "forever": "^2.0.0",


### PR DESCRIPTION
This PR fixes generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash--tmp-b3338df8-e368-45b5-9600-cf63dc17dc03-artifacts-db-reset.js.